### PR TITLE
Disable unnecessary repositories

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,9 @@
 FROM fedora:34
 
+RUN sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo \
+	&& sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-modular.repo \
+	&& sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-updates-modular.repo
+
 RUN dnf -y update \
 	&& dnf -y install pip \
 	&& dnf clean all


### PR DESCRIPTION
We frequently see the bugwatcher job fail to build the container image
due to the inability to fetch these repositories.

Disable them as they're not needed.

The usual way to disable the repositories with DNF would be to use the
`dnf config-manager --set-disabled` command, however it is part of
dnf-plugins-core package that is not installed in the fedora container
image. Instead we modify the repository files directly with `sed`.