### PR TITLE
Safe usage of DNF for CI

### DIFF
--- a/pretriage/Containerfile
+++ b/pretriage/Containerfile
@@ -1,16 +1,15 @@
 FROM fedora:34
 
+WORKDIR /src
+COPY ./pretriage/ ./
+
 RUN sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo \
 	&& sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-modular.repo \
 	&& sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-updates-modular.repo
 
-RUN dnf -y update \
-	&& dnf -y install pip \
+RUN ./dnf_safe -y update \
+	&& ./dnf_safe -y install pip \
 	&& dnf clean all
 
 RUN pip install --upgrade pip && pip install pycodestyle
-
-WORKDIR /src
-COPY ./pretriage/ ./
-
 RUN pip install --requirement requirements.txt

--- a/pretriage/dnf_safe
+++ b/pretriage/dnf_safe
@@ -1,0 +1,54 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#
+# This script will run any DNF command and stop until the command returns 0
+# Usage:
+# ./dnf_safe install python3-openstackclient -y
+# This will attempts to intall openstackclient, until it works, up to 10 attempts
+# and a break of 5 seconds between retries.
+#
+
+set -eu
+DEBUG=${DEBUG:-}
+if [ -n "$DEBUG" ]; then
+    set -x
+fi
+
+# Function to run a command with a retry.
+# You can specify the number of total retries in $1
+# and the sleep time (in seconds) between retries.
+function retry {
+    local retries=$1
+    local time=$2
+    shift 2
+
+    local count=0
+    until "$@"; do
+      exit=$?
+      count=$(($count + 1))
+      if [ $count -lt $retries ]; then
+        echo "Failed to run 'dnf' after $count attempts, will retry in $time..."
+        sleep $time
+      else
+        return $exit
+      fi
+    done
+    return 0
+}
+
+retry 10 5 sudo dnf "$@"


### PR DESCRIPTION
Like we did for shiftstack-ci, let's have a small util to use DNF in
retry mode, which will avoid some CI errors when Fedora repos are
unavailable at that time.
