### PR TITLE
pretriage: Ensure randomness

### DIFF
--- a/pretriage/requirements.txt
+++ b/pretriage/requirements.txt
@@ -1,2 +1,3 @@
 python-bugzilla
 tenacity
+ntplib


### PR DESCRIPTION
With this patch, the random selection of a team member does not rely on
internal entropy sources, which may be hard to get in a containerised
environment. The PRNG is now seeded using nanosecond time from NTP.