### PR TITLE
Add an online help

### DIFF
--- a/posttriage.py
+++ b/posttriage.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import argparse
 import bugzilla
 
 
@@ -78,4 +79,6 @@ def run():
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Resets the "Triaged" keyword on bugs that still need attention.')
+    args = parser.parse_args()
     run()

--- a/pretriage.py
+++ b/pretriage.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import argparse
 import json
 import sys
 import ntplib
@@ -96,4 +97,6 @@ def run():
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Finds untriaged, unassigned ShiftStack bugs and assigns them to a team member.')
+    args = parser.parse_args()
     run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length=150


### PR DESCRIPTION
Among other uses, could make up for a presubmit dry-run in the CI.