### PR TITLE
pretriage: Drop non-existant component

### DIFF
--- a/cmd/pretriage/main.go
+++ b/cmd/pretriage/main.go
@@ -28,7 +28,6 @@ const query = `
 			component in (
 				"Installer",
 				"Machine Config Operator",
-				"Machine Config Operator/Machine Config Operator",
 				"Machine Config Operator/platform-none",
 				"Cloud Compute/Cloud Controller Manager",
 				"Cloud Compute/Cluster Autoscaler",


### PR DESCRIPTION
The component `Machine Config Operator/Machine Config Operator` was
apparently removed from the Jira OCPBUGS project.