### PR TITLE
pretriage: Do not assign to vacating team members

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,40 @@ Required environment variables:
 * `BUGZILLA_API_KEY`: a [Bugzilla API key](https://bugzilla.redhat.com/userprefs.cgi?tab=apikey)
 * `JIRA_TOKEN`: a [Jira API token](https://issues.redhat.com/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens) of an account that can access the OCPBUGS project
 * `SLACK_HOOK`: a [Slack hook](https://api.slack.com/messaging/webhooks) URL
-* `TEAM_MEMBERS` is a JSON object in the form:
+* `TEAM_MEMBERS_DICT` is a JSON object in the form:
 
 ```json
-[
-  {
+{
+  "kerberos_id1": {
     "slack_id": "UG65473AM",
     "bz_id": "user1@example.com",
     "components": ["component1"],
     "jira_name": "user1",
     "jira_components": ["component1/sub-component1"]
   },
-  {
+  "kerberos_id2": {
     "slack_id": "UGF8B93HA",
     "bz_id": "user2@example.com",
     "components": [],
     "jira_name": "user2",
     "jira_components": []
+  }
+}
+```
+
+Optional environment variable: `TEAM_VACATION` in the form:
+
+```json
+[
+  {
+    "kerberos": "jdoe",
+    "start": "2022-01-01",
+    "end": "2022-01-15"
+  },
+  {
+    "kerberos": "jdoe",
+    "start": "2022-06-12",
+    "end": "2022-06-15"
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -90,20 +90,7 @@ Required environment variables:
 
 * `BUGZILLA_API_KEY`: a [Bugzilla API key](https://bugzilla.redhat.com/userprefs.cgi?tab=apikey)
 * `SLACK_HOOK`: a [Slack hook](https://api.slack.com/messaging/webhooks) URL
-* `TEAM_MEMBERS` is a JSON object in the form:
-
-```json
-[
-  {
-    "slack_id": "UG65473AM",
-    "bz_id": "user1@example.com"
-  },
-  {
-    "slack_id": "UGF8B93HA",
-    "bz_id": "user2@example.com"
-  }
-]
-```
+* `TEAM_MEMBERS_DICT` as described above
 
 ### Development
 

--- a/cmd/pretriage/main.go
+++ b/cmd/pretriage/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 	"math/rand"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -44,18 +44,16 @@ const query = `
 	`
 
 var (
-	SLACK_HOOK   = os.Getenv("SLACK_HOOK")
-	JIRA_TOKEN   = os.Getenv("JIRA_TOKEN")
-	TEAM_MEMBERS = os.Getenv("TEAM_MEMBERS")
+	SLACK_HOOK        = os.Getenv("SLACK_HOOK")
+	JIRA_TOKEN        = os.Getenv("JIRA_TOKEN")
+	TEAM_MEMBERS_DICT = os.Getenv("TEAM_MEMBERS_DICT")
+	TEAM_VACATION     = os.Getenv("TEAM_VACATION")
 )
 
 func main() {
 	var team Team
-	{
-		err := json.Unmarshal([]byte(TEAM_MEMBERS), &team)
-		if err != nil {
-			log.Fatalf("error unmarshaling TEAM_MEMBERS: %v", err)
-		}
+	if err := team.Load(strings.NewReader(TEAM_MEMBERS_DICT), strings.NewReader(TEAM_VACATION)); err != nil {
+		log.Fatalf("error unmarshaling TEAM_MEMBERS_DICT: %v", err)
 	}
 
 	var jiraClient *jira.Client
@@ -119,9 +117,13 @@ func init() {
 		log.Print("Required environment variable not found: JIRA_TOKEN")
 	}
 
-	if TEAM_MEMBERS == "" {
+	if TEAM_MEMBERS_DICT == "" {
 		ex_usage = true
-		log.Print("Required environment variable not found: TEAM_MEMBERS")
+		log.Print("Required environment variable not found: TEAM_MEMBERS_DICT")
+	}
+
+	if TEAM_VACATION == "" {
+		TEAM_VACATION = "[]"
 	}
 
 	if ex_usage {

--- a/cmd/pretriage/team.go
+++ b/cmd/pretriage/team.go
@@ -2,8 +2,31 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"math/rand"
+	"time"
 )
+
+type Date time.Time
+
+func (d *Date) UnmarshalJSON(src []byte) error {
+	var datestring string
+	if err := json.Unmarshal(src, &datestring); err != nil {
+		return err
+	}
+
+	t, err := time.Parse("2006-01-02", datestring)
+	if err != nil {
+		return err
+	}
+
+	*d = Date(t)
+	return nil
+}
+
+func (d Date) Before(t time.Time) bool { return time.Time(d).Before(t) }
+func (d Date) After(t time.Time) bool  { return time.Time(d).After(t) }
 
 type Team map[string][]TeamMember
 
@@ -12,16 +35,37 @@ type TeamMember struct {
 	JiraName string
 }
 
-func (t *Team) UnmarshalJSON(data []byte) error {
-	var members []struct {
+func (t *Team) Load(teamJSON, vacationJSON io.Reader) error {
+	var members map[string]struct {
 		SlackId    string   `json:"slack_id"`
 		JiraName   string   `json:"jira_name"`
 		Components []string `json:"jira_components"`
 	}
 
-	if err := json.Unmarshal(data, &members); err != nil {
-		return err
+	if err := json.NewDecoder(teamJSON).Decode(&members); err != nil {
+		return fmt.Errorf("failed to unmarshal team: %w", err)
 	}
+
+	// Apply vacation
+	{
+		var vacation []struct {
+			Kerberos string `json:"kerberos"`
+			Start    Date   `json:"start"`
+			End      Date   `json:"end"`
+		}
+
+		if err := json.NewDecoder(vacationJSON).Decode(&vacation); err != nil {
+			return fmt.Errorf("failed to unmarshal vacation: %w", err)
+		}
+
+		now := time.Now()
+		for _, v := range vacation {
+			if v.End.After(now) && v.Start.Before(now) {
+				delete(members, v.Kerberos)
+			}
+		}
+	}
+
 	team := make(map[string][]TeamMember)
 	for _, member := range members {
 		for _, component := range append(member.Components, "") {

--- a/doctext.py
+++ b/doctext.py
@@ -81,13 +81,14 @@ def fetch_bugs(bugzilla_api_key, team, slack_hook):
 
 
 def run():
-    team = os.getenv("TEAM_MEMBERS")
+    team = os.getenv("TEAM_MEMBERS_DICT")
     if team is None:
         sys.exit(
             ("Error: the JSON object describing the team is required. Set the "
-             "TEAM_MEMBERS environment variable.")
+             "TEAM_MEMBERS_DICT environment variable.")
         )
     team = json.loads(team)
+    team = [team[member] for member in team]
 
     slack_hook = os.getenv("SLACK_HOOK")
     if slack_hook is None:


### PR DESCRIPTION
Depends on: https://github.com/openshift/release/pull/31064

Introduce a new optional environment variable: `TEAM_VACATION`. Team members in vacation state won't be assigned triage.