### PR TITLE
doctext: Call it "Release Note Text" in Jira

### DIFF
--- a/cmd/doctext/notify.go
+++ b/cmd/doctext/notify.go
@@ -13,7 +13,7 @@ import (
 
 func notification(issues []jira.Issue, assignee TeamMember) string {
 	var notification strings.Builder
-	notification.WriteString("<@" + assignee.SlackId + "> please check the doctext for these bugs:")
+	notification.WriteString("<@" + assignee.SlackId + "> please check the Release Note Text of these bugs:")
 	for _, issue := range issues {
 		notification.WriteString(fmt.Sprintf(" <%s|%s>", jiraBaseURL+"browse/"+issue.Key, issue.Key))
 	}


### PR DESCRIPTION
For that's how the "doctext" field is called in Jira.