### PR TITLE
Add MCO platform-none component to doctext and posttriage search

### DIFF
--- a/cmd/doctext/main.go
+++ b/cmd/doctext/main.go
@@ -25,11 +25,13 @@ const (
 				"Cloud Compute / OpenStack Provider",
 				"Machine Config Operator / platform-openstack",
 				"Networking / kuryr",
-				"Test Framework / OpenStack")
+				"Test Framework / OpenStack"
+			)
 			OR (
 				component in (
 					"Installer",
 					"Machine Config Operator",
+					"Machine Config Operator / platform-none",
 					"Cloud Compute / Cloud Controller Manager",
 					"Cloud Compute / Cluster Autoscaler",
 					"Cloud Compute / MachineHealthCheck",

--- a/cmd/posttriage/main.go
+++ b/cmd/posttriage/main.go
@@ -24,11 +24,13 @@ const (
 				"Cloud Compute / OpenStack Provider",
 				"Machine Config Operator / platform-openstack",
 				"Networking / kuryr",
-				"Test Framework / OpenStack")
+				"Test Framework / OpenStack"
+			)
 			OR (
 				component in (
 					"Installer",
 					"Machine Config Operator",
+					"Machine Config Operator / platform-none",
 					"Cloud Compute / Cloud Controller Manager",
 					"Cloud Compute / Cluster Autoscaler",
 					"Cloud Compute / MachineHealthCheck",


### PR DESCRIPTION
This will only match if the issue has osp or openstack in its summary.