### PR TITLE
Use user group ID for team notifications

### DIFF
--- a/cmd/doctext/notify.go
+++ b/cmd/doctext/notify.go
@@ -12,8 +12,15 @@ import (
 )
 
 func notification(issues []jira.Issue, assignee TeamMember) string {
+	var slackId string
+	if strings.HasPrefix(assignee.SlackId, "!subteam^") {
+		slackId = "<" + assignee.SlackId + ">"
+	} else {
+		slackId = "<@" + assignee.SlackId + ">"
+	}
+
 	var notification strings.Builder
-	notification.WriteString("<@" + assignee.SlackId + "> please check the Release Note Text of these bugs:")
+	notification.WriteString(slackId + " please check the Release Note Text of these bugs:")
 	for _, issue := range issues {
 		notification.WriteString(fmt.Sprintf(" <%s|%s>", jiraBaseURL+"browse/"+issue.Key, issue.Key))
 	}

--- a/cmd/doctext/team.go
+++ b/cmd/doctext/team.go
@@ -47,7 +47,9 @@ func (t *Team) Load(teamJSON io.Reader) error {
 
 	// team is a map of JiraID to TeamMember
 	team := map[string]TeamMember{
-		"team": {SlackId: "openstack-dev-team", JiraName: "team"},
+		// ID of openstack-dev-team user group
+		// https://api.slack.com/reference/surfaces/formatting#mentioning-groups
+		"team": {SlackId: "!subteam^SKW6QC31Q", JiraName: "team"},
 	}
 
 	for _, member := range members {

--- a/cmd/triage/notify.go
+++ b/cmd/triage/notify.go
@@ -12,8 +12,15 @@ import (
 )
 
 func notification(issues []jira.Issue, assignee TeamMember) string {
+	var slackId string
+	if strings.HasPrefix(assignee.SlackId, "!subteam^") {
+		slackId = "<" + assignee.SlackId + ">"
+	} else {
+		slackId = "<@" + assignee.SlackId + ">"
+	}
+
 	var notification strings.Builder
-	notification.WriteString("<@" + assignee.SlackId + "> please triage these bugs:")
+	notification.WriteString(slackId + " please triage these bugs:")
 	for _, issue := range issues {
 		notification.WriteString(fmt.Sprintf(" <%s|%s>", jiraBaseURL+"browse/"+issue.Key, issue.Key))
 	}

--- a/cmd/triage/team.go
+++ b/cmd/triage/team.go
@@ -25,7 +25,9 @@ func (t *Team) Load(teamJSON io.Reader) error {
 
 	// team is a map of JiraID to TeamMember
 	team := map[string]TeamMember{
-		"team": {SlackId: "openstack-dev-team", JiraName: "team"},
+		// ID of openstack-dev-team user group
+		// https://api.slack.com/reference/surfaces/formatting#mentioning-groups
+		"team": {SlackId: "!subteam^SKW6QC31Q", JiraName: "team"},
 	}
 	for _, member := range members {
 		team[member.JiraName] = TeamMember{SlackId: member.SlackId, JiraName: member.JiraName}


### PR DESCRIPTION
Mentioning a [user group][1] requires a different format from mentioning a [user][2].

[1]: https://api.slack.com/reference/surfaces/formatting#mentioning-groups
[2]: https://api.slack.com/reference/surfaces/formatting#mentioning-users
