### PR TITLE
posttriage: Untriage lowercase 'triage' label

### DIFF
--- a/cmd/posttriage/update.go
+++ b/cmd/posttriage/update.go
@@ -17,7 +17,7 @@ func untriage(ctx context.Context, jiraClient *jira.Client, issue jira.Issue, co
 	{
 		res, err := jiraClient.Issue.UpdateIssueWithContext(ctx, issue.ID, map[string]interface{}{
 			"update": map[string]interface{}{
-				"labels": json.RawMessage(`[{"remove":"Triaged"}]`),
+				"labels": json.RawMessage(`[{"remove":"Triaged"},{"remove":"triaged"}]`),
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
In Jira, the search by label is case insensitive, while label removal matches case sensitively.

Before this patch, an issue labeled `triaged` would propertly get identified as triaged; however untriaging it would (silently) fail because we were only removing the capitalised label `Triaged`.

This patch makes the untriage function remove both `Triaged` and `triaged`. Please do not mark your issues as `triAged`.