### PR TITLE
pretriage: Handle the case where no team member is available

### DIFF
--- a/cmd/pretriage/team.go
+++ b/cmd/pretriage/team.go
@@ -30,9 +30,24 @@ func (d Date) After(t time.Time) bool  { return time.Time(d).After(t) }
 
 type Team map[string][]TeamMember
 
+type Leave struct {
+	Start Date `json:"start"`
+	End   Date `json:"end"`
+}
+
 type TeamMember struct {
 	SlackId  string
 	JiraName string
+	vacation []Leave
+}
+
+func (m TeamMember) IsAvailable(t time.Time) bool {
+	for _, leave := range m.vacation {
+		if leave.End.After(t) && leave.Start.Before(t) {
+			return false
+		}
+	}
+	return true
 }
 
 func (t *Team) Load(teamJSON, vacationJSON io.Reader) error {
@@ -40,6 +55,7 @@ func (t *Team) Load(teamJSON, vacationJSON io.Reader) error {
 		SlackId    string   `json:"slack_id"`
 		JiraName   string   `json:"jira_name"`
 		Components []string `json:"jira_components"`
+		vacation   []Leave
 	}
 
 	if err := json.NewDecoder(teamJSON).Decode(&members); err != nil {
@@ -58,10 +74,12 @@ func (t *Team) Load(teamJSON, vacationJSON io.Reader) error {
 			return fmt.Errorf("failed to unmarshal vacation: %w", err)
 		}
 
-		now := time.Now()
-		for _, v := range vacation {
-			if v.End.After(now) && v.Start.Before(now) {
-				delete(members, v.Kerberos)
+		for _, leave := range vacation {
+			if m, ok := members[leave.Kerberos]; ok {
+				m.vacation = append(m.vacation, Leave{
+					Start: leave.Start,
+					End:   leave.End,
+				})
 			}
 		}
 	}
@@ -69,7 +87,7 @@ func (t *Team) Load(teamJSON, vacationJSON io.Reader) error {
 	team := make(map[string][]TeamMember)
 	for _, member := range members {
 		for _, component := range append(member.Components, "") {
-			team[component] = append(team[component], TeamMember{SlackId: member.SlackId, JiraName: member.JiraName})
+			team[component] = append(team[component], TeamMember{SlackId: member.SlackId, JiraName: member.JiraName, vacation: member.vacation})
 		}
 	}
 
@@ -77,12 +95,39 @@ func (t *Team) Load(teamJSON, vacationJSON io.Reader) error {
 	return nil
 }
 
-func (t Team) NewAssignee(component string) TeamMember {
-	specialists := t[""]
+// Specialists returns the team members assigned to that component. If the
+// component isn't known, Specialists returns the whole team.
+func (t Team) Specialists(component string) []TeamMember {
 	if s, ok := t[component]; ok {
-		specialists = s
+		return s
 	}
-	return specialists[rand.Intn(len(specialists))]
+	return t[""]
+}
+
+var (
+	ErrEmptyTeam    error = fmt.Errorf("no team members to choose from")
+	ErrVacatingTeam error = fmt.Errorf("no available specialist team members")
+)
+
+// RandomAvailable returns a random team member from the given slice, that
+// isn't vacating. If the slice is empty, or if all members are vacating,
+// RandomAvailable returns a non-nil error.
+func RandomAvailable(team []TeamMember, t time.Time) (TeamMember, error) {
+	if len(team) == 0 {
+		return TeamMember{}, ErrEmptyTeam
+	}
+
+	availableMembers := make([]TeamMember, 0, len(team))
+	for _, member := range team {
+		if member.IsAvailable(t) {
+			availableMembers = append(availableMembers, member)
+		}
+	}
+	if len(availableMembers) == 0 {
+		return TeamMember{}, ErrVacatingTeam
+	}
+
+	return availableMembers[rand.Intn(len(availableMembers))], nil
 }
 
 // MemberByJiraName returns the first team member found that has the given Jira


### PR DESCRIPTION
Also, with this patch the pretriage's team logic is made more compatible with the other bugwatcher bot's team logic, so that we can hopefully extract team logic to a separate package soon.