### PR TITLE
doctext: Change custom field

### DIFF
--- a/cmd/doctext/checks.go
+++ b/cmd/doctext/checks.go
@@ -9,7 +9,7 @@ import jira "github.com/andygrunwald/go-jira"
 type triageCheck func(jira.Issue) (triaged bool, msg string, err error)
 
 func docTextCheck(issue jira.Issue) (bool, string, error) {
-	if issue.Fields.Unknowns["customfield_12310211"] == nil {
+	if issue.Fields.Unknowns["customfield_12317313"] == nil {
 		return false, "the Release Note Text is missing", nil
 	}
 	return true, "", nil


### PR DESCRIPTION
issues.redhat.com is using a new custom field, `customfield_12317313`, for `Release Note Text`. The old one, `customfield_12310211`, is now called `Release Note Text_Old`. You can view this at https://issues.redhat.com/rest/api/latest/field (per the [JIRA KB](https://confluence.atlassian.com/jirakb/how-to-find-any-custom-field-s-ids-744522503.html)).

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
