### PR TITLE
doctext: Also consider Release Note Type

### DIFF
--- a/cmd/doctext/checks.go
+++ b/cmd/doctext/checks.go
@@ -9,8 +9,18 @@ import jira "github.com/andygrunwald/go-jira"
 type triageCheck func(jira.Issue) (triaged bool, msg string, err error)
 
 func docTextCheck(issue jira.Issue) (bool, string, error) {
-	if issue.Fields.Unknowns["customfield_12317313"] == nil {
-		return false, "the Release Note Text is missing", nil
+	// We must set the type and (optionally) the text for release notes. The
+	// text must always be set unless the type is "No Doc Update".
+	//
+	// Release Note Type -> customfield_12320850
+	// Release Note Text -> customfield_12317313
+	if issue.Fields.Unknowns["customfield_12320850"] != nil {
+		if issue.Fields.Unknowns["customfield_12320850"] == "No Doc Update" {
+			return true, "", nil
+		}
+		if issue.Fields.Unknowns["customfield_12317313"] != nil {
+			return true, "", nil
+		}
 	}
-	return true, "", nil
+	return false, "the Release Note Text is missing", nil
 }


### PR DESCRIPTION
As noted previously, issues.redhat.com is using a new custom field, `customfield_12317313`, for 'Release Note Text'. However, it's also using a wholly new custom field, `customfield_12320850` or 'Release Note Type'. This can be set to various values, one of which is 'No Doc Update'. If set to this value, clearly we can get away with no setting the 'Release Note Text' field.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
