### PR TITLE
Add debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 ## pretriage
 
-Usage:
+**Usage:**
+
 ```shell
 go build ./cmd/pretriage && ./pretriage`
 ```
 
 Finds untriaged, unassigned Shiftstack bugs and assigns them to a team member.
 
-Required environment variables:
+**Required environment variables:**
 
 * `JIRA_TOKEN`: a [Jira API token](https://issues.redhat.com/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens) of an account that can access the OCPBUGS project
 * `SLACK_HOOK`: a [Slack hook](https://api.slack.com/messaging/webhooks) URL
-* `TEAM_MEMBERS_DICT` is a JSON object in the form:
+* `TEAM_MEMBERS_DICT`: a JSON object in the form:
 
 ```json
 {
@@ -34,7 +35,9 @@ Required environment variables:
 }
 ```
 
-Optional environment variable: `TEAM_VACATION` in the form:
+**Optional environment variables:**
+
+* `TEAM_VACATION`: a JSON object in the form:
 
 ```json
 [
@@ -53,28 +56,34 @@ Optional environment variable: `TEAM_VACATION` in the form:
 
 ## posttriage
 
-Usage:
+**Usage:**
+
 ```shell
 go build ./cmd/posttriage && ./posttriage
 ```
 
 Resets the `Triaged` keyword on bugs that still need attention.
 
-Required environment variables:
+**Required environment variables:**
 
 * `JIRA_TOKEN`: a [Jira API token](https://issues.redhat.com/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens) of an account that can access the OCPBUGS project
 
 ## doctext
 
-Usage:
+**Usage:**
+
 ```shell
 go build ./cmd/doctext && ./doctext
 ```
 
 Finds resolved bugs lacking a doc text, and posts a reminder to Slack.
 
-Required environment variables:
+**Required environment variables:**
 
 * `JIRA_TOKEN`: a [Jira API token](https://issues.redhat.com/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens) of an account that can access the OCPBUGS project
-* `SLACK_HOOK`: a [Slack hook](https://api.slack.com/messaging/webhooks) URL
-* `TEAM_MEMBERS_DICT` is a JSON object in the form:
+* `SLACK_HOOK`: a [Slack hook](https://api.slack.com/messaging/webhooks) URL (optional and ignored if `BUGWATCHER_DEBUG` set)
+* `TEAM_MEMBERS_DICT`: a JSON object in the form described previously (optional and ignored if `BUGWATCHER_DEBUG` set)
+
+**Optional environment variables:**
+
+* `BUGWATCHER_DEBUG`: enable debug mode, where found bugs are logged to output instead of Slack


### PR DESCRIPTION
It can be helpful to debug the behavior of the bot tools without having anything post to Slack. Make this possible, starting with the doctext tool.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
