### PR TITLE
pretriage: Re-assign bugs assigned to default assignee

### DIFF
--- a/cmd/pretriage/main.go
+++ b/cmd/pretriage/main.go
@@ -13,7 +13,16 @@ import (
 	"github.com/shiftstack/bugwatcher/pkg/query"
 )
 
-const queryUntriaged = query.ShiftStack + `AND assignee is EMPTY AND (labels not in ("Triaged") OR labels is EMPTY)`
+const queryUntriaged = query.ShiftStack + `
+	AND (
+		(
+			assignee is EMPTY AND (labels not in ("Triaged") OR labels is EMPTY)
+		)
+		OR (
+			assignee = "shiftstack-dev@redhat.com"
+		)
+	)
+`
 
 var (
 	SLACK_HOOK        = os.Getenv("SLACK_HOOK")


### PR DESCRIPTION
It seems bugs are going to be assigned to a default assignee in the near future. We're going to use an alias as our default. Extend the pretriage bot's query to select bugs assigned to this alias and re-assign them to humans.
