### PR TITLE
Vacation

### DIFF
--- a/cmd/pretriage/main.go
+++ b/cmd/pretriage/main.go
@@ -100,6 +100,8 @@ func main() {
 }
 
 func init() {
+	log.SetFlags(log.Ldate | log.Ltime | log.LUTC)
+
 	ex_usage := false
 	if SLACK_HOOK == "" {
 		ex_usage = true

--- a/cmd/pretriage/team.go
+++ b/cmd/pretriage/team.go
@@ -80,6 +80,7 @@ func (t *Team) Load(teamJSON, vacationJSON io.Reader) error {
 					Start: leave.Start,
 					End:   leave.End,
 				})
+				members[leave.Kerberos] = m
 			}
 		}
 	}

--- a/cmd/pretriage/team.go
+++ b/cmd/pretriage/team.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"time"
 )
@@ -74,13 +75,15 @@ func (t *Team) Load(teamJSON, vacationJSON io.Reader) error {
 			return fmt.Errorf("failed to unmarshal vacation: %w", err)
 		}
 
-		for _, leave := range vacation {
+		for i, leave := range vacation {
 			if m, ok := members[leave.Kerberos]; ok {
 				m.vacation = append(m.vacation, Leave{
 					Start: leave.Start,
 					End:   leave.End,
 				})
 				members[leave.Kerberos] = m
+			} else {
+				log.Printf("warning: vacation entry with index %d did not apply to any team member", i)
 			}
 		}
 	}


### PR DESCRIPTION
Before this patch, vacation was applied to a struct that was immediately discarded.

See this example: https://go.dev/play/p/McHq07KBmrV

---

Also print log timestamps in UTC.