### PR TITLE
triage: Ignore bugs with needinfo

### DIFF
--- a/cmd/triage/main.go
+++ b/cmd/triage/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shiftstack/bugwatcher/pkg/query"
 )
 
-const queryUntriaged = query.ShiftStack + `AND (labels not in ("Triaged") OR labels is EMPTY)`
+const queryUntriaged = query.ShiftStack + `AND (labels not in ("Triaged") OR labels is EMPTY) AND "Need Info From" is EMPTY`
 
 var (
 	SLACK_HOOK        = os.Getenv("SLACK_HOOK")


### PR DESCRIPTION
We can consider any bug that has the "Need Info From" field set to not require triage yet, since we're waiting on info from the requestee. Note that we don't filter out team members from this and instead look for *any* needinfo. This has the potential to cause false positives if the needinfo is on one of the team members, but that seems like an acceptable risk given said team member will be getting notifications. It also allows us to do this via the query rather than filtering issues and we work through them.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
