### PR TITLE
pretriage: Reassign bugs assigned to the bot

### DIFF
--- a/cmd/pretriage/main.go
+++ b/cmd/pretriage/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shiftstack/bugwatcher/pkg/query"
 )
 
-const queryUntriaged = query.ShiftStack + `AND assignee is EMPTY AND (labels not in ("Triaged") OR labels is EMPTY)`
+const queryUntriaged = query.ShiftStack + `AND ( assignee is EMPTY OR assignee = shiftstack ) AND (labels not in ("Triaged") OR labels is EMPTY)`
 
 var (
 	SLACK_HOOK        = os.Getenv("SLACK_HOOK")


### PR DESCRIPTION
Treat bugs assigned to the bot as if they were unassigned. That is: reassign bugs that are assigned to the bot.

@stephenfin would this solve the problem for which you wrote https://github.com/shiftstack/bugwatcher/pull/65?