### PR TITLE
pretriage: Use logs to advertise the two operations

### DIFF
--- a/cmd/pretriage/main.go
+++ b/cmd/pretriage/main.go
@@ -50,7 +50,7 @@ func main() {
 	var wg sync.WaitGroup
 	var gotErrors bool
 
-	// first, pre-set any necessary fields for the ART reconciliation bugs to avoid "busy work"...
+	log.Print("pre-setting any necessary fields for the ART reconciliation bugs...")
 	for issue := range query.SearchIssues(context.Background(), jiraClient, queryARTReconciliation) {
 		wg.Add(1)
 		go func(issue jira.Issue) {
@@ -96,7 +96,7 @@ func main() {
 	slackClient := &http.Client{}
 	now := time.Now()
 
-	// ...then do the actual triage assignment
+	log.Print("Running the actual triage assignment...")
 	for issue := range query.SearchIssues(context.Background(), jiraClient, queryUntriaged) {
 		wg.Add(1)
 		go func(issue jira.Issue) {


### PR DESCRIPTION
Turn comments into runtime logs.

The [current logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-shiftstack-ci-main-bugwatcher-pretriage/1803806554701434880/artifacts/bugwatcher-pretriage/shiftstack-bugwatcher-pretriage/build-log.txt) are a bit arid:

```plaintext
2024/06/20 15:06:29 Incoming batch of 0 issues
2024/06/20 15:06:30 Incoming batch of 0 issues
```