### PR TITLE
Makefile: `make` should build, not run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,3 @@
-run-pretriage: pretriage
-	./hack/run_with_env.sh ./$<
-.PHONY: run-pretriage
-
-lint:
-	gofmt -w -s cmd pkg
-.PHONY: lint
-
 build: pretriage triage posttriage doctext
 
 pretriage: cmd/pretriage pkg/query
@@ -19,3 +11,11 @@ posttriage: cmd/posttriage pkg/query
 
 doctext: cmd/doctext pkg/query
 	go build ./$<
+
+lint:
+	gofmt -w -s cmd pkg
+.PHONY: lint
+
+run-pretriage: pretriage
+	./hack/run_with_env.sh ./$<
+.PHONY: run-pretriage

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Optional environment variable: `TEAM_VACATION` in the form:
 ]
 ```
 
+### Local testing
+
+A local script will set the required environment variables for you if you
+provide a [vault](https://vault.ci.openshift.org) token.
+
+```shell
+export VAULT_TOKEN=$vault_token
+make run-pretriage
+```
+
 ## triage
 
 Usage:


### PR DESCRIPTION
Build all binaries with `make`. Run pretriage with `make run-pretriage`