### PR TITLE
posttriage: Don't insist on priority for non-bugs

### DIFF
--- a/cmd/posttriage/checks.go
+++ b/cmd/posttriage/checks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"slices"
 
 	jira "github.com/andygrunwald/go-jira"
 )
@@ -13,6 +14,12 @@ import (
 type triageCheck func(jira.Issue) (triaged bool, msg string, err error)
 
 func priorityCheck(issue jira.Issue) (bool, string, error) {
+	// If a bug has been closed as a non-bug, we shouldn't insist on a priority.
+	// Taken from https://issues.redhat.com/rest/api/2/resolution
+	nonBugs := []string{"Won't Do", "Cannot Reproduce", "Can't Do", "Duplicate", "Not a bug", "Obsolete"}
+	if slices.Contains(nonBugs, issue.Fields.Resolution.Name) {
+		return true, "", nil
+	}
 	if issue.Fields.Priority == nil || issue.Fields.Priority.Name == "Undefined" {
 		return false, "the Priority assessment is missing", nil
 	}


### PR DESCRIPTION
If a bug was closed as e.g. "Not a bug" then defining a priority doesn't make any sense. Stop insisting on it.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
