### PR TITLE
Fix nil pointer dereference in priorityCheck function

### DIFF
--- a/cmd/posttriage/checks.go
+++ b/cmd/posttriage/checks.go
@@ -15,9 +15,11 @@ type triageCheck func(jira.Issue) (triaged bool, msg string, err error)
 func priorityCheck(issue jira.Issue) (bool, string, error) {
 	// If a bug has been closed as a non-bug, we shouldn't insist on a priority.
 	// Taken from https://issues.redhat.com/rest/api/2/resolution
-	switch issue.Fields.Resolution.Name {
-	case "Won't Do", "Cannot Reproduce", "Can't Do", "Duplicate", "Not a bug", "Obsolete":
-		return true, "", nil
+	if issue.Fields.Resolution != nil {
+		switch issue.Fields.Resolution.Name {
+		case "Won't Do", "Cannot Reproduce", "Can't Do", "Duplicate", "Not a bug", "Obsolete":
+			return true, "", nil
+		}
 	}
 	if issue.Fields.Priority == nil || issue.Fields.Priority.Name == "Undefined" {
 		return false, "the Priority assessment is missing", nil


### PR DESCRIPTION
Added a conditional check to handle cases where the resolution field is nil, preventing potential nil pointer dereference. The string returned in the error message might need to be updated 