### PR TITLE
Simplify bug query

### DIFF
--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -12,19 +12,5 @@ const ShiftStack = `project = "OpenShift Bugs"
 			"Networking / kuryr",
 			"Test Framework / OpenStack"
 		)
-		OR (
-			component in (
-				"Installer",
-				"Machine Config Operator",
-				"Machine Config Operator / platform-none",
-				"Cloud Compute / Cloud Controller Manager",
-				"Cloud Compute / Cluster Autoscaler",
-				"Cloud Compute / MachineHealthCheck",
-				"Cloud Compute / Unknown")
-			AND (
-				summary ~ "osp"
-				OR summary ~ "openstack"
-			)
-		)
 	)
 `


### PR DESCRIPTION
To track all pertinent bugs, our Jira board historically has two parts:
* include all OCPBUGS issues with our components
* include all OCPBUGS with components adjacent to ours, and with "openstack" in the summary

In Bugzilla, this was useful.

However, the second part of the query only seems to catch false positives lately.

This commit removes the second part, simplifying the bug query to just trust the Component assignment of the bug.