### PR TITLE
Retry when hitting 429 TooManyRequests

### DIFF
--- a/cmd/doctext/main.go
+++ b/cmd/doctext/main.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	jira "github.com/andygrunwald/go-jira"
+	"github.com/shiftstack/bugwatcher/pkg/jiraclient"
 	"github.com/shiftstack/bugwatcher/pkg/query"
 )
 
@@ -28,16 +29,9 @@ func main() {
 		log.Fatalf("error unmarshaling TEAM_MEMBERS_DICT: %v", err)
 	}
 
-	var jiraClient *jira.Client
-	{
-		var err error
-		jiraClient, err = jira.NewClient(
-			(&jira.BearerAuthTransport{Token: JIRA_TOKEN}).Client(),
-			query.JiraBaseURL,
-		)
-		if err != nil {
-			log.Fatalf("FATAL: error building a Jira client: %v", err)
-		}
+	jiraClient, err := jiraclient.NewWithToken(query.JiraBaseURL, JIRA_TOKEN)
+	if err != nil {
+		log.Fatalf("error building a Jira client: %v", err)
 	}
 
 	triageChecks := [...]triageCheck{

--- a/cmd/posttriage/main.go
+++ b/cmd/posttriage/main.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	jira "github.com/andygrunwald/go-jira"
+	"github.com/shiftstack/bugwatcher/pkg/jiraclient"
 	"github.com/shiftstack/bugwatcher/pkg/query"
 )
 
@@ -18,16 +19,9 @@ var JIRA_TOKEN = os.Getenv("JIRA_TOKEN")
 func main() {
 	ctx := context.Background()
 
-	var jiraClient *jira.Client
-	{
-		var err error
-		jiraClient, err = jira.NewClient(
-			(&jira.BearerAuthTransport{Token: JIRA_TOKEN}).Client(),
-			query.JiraBaseURL,
-		)
-		if err != nil {
-			log.Fatalf("FATAL: error building a Jira client: %v", err)
-		}
+	jiraClient, err := jiraclient.NewWithToken(query.JiraBaseURL, JIRA_TOKEN)
+	if err != nil {
+		log.Fatalf("error building a Jira client: %v", err)
 	}
 
 	triageChecks := [...]triageCheck{

--- a/cmd/pretriage/main.go
+++ b/cmd/pretriage/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	jira "github.com/andygrunwald/go-jira"
+	"github.com/shiftstack/bugwatcher/pkg/jiraclient"
 	"github.com/shiftstack/bugwatcher/pkg/query"
 )
 
@@ -35,16 +36,9 @@ func main() {
 		log.Fatalf("error unmarshaling TEAM_MEMBERS_DICT: %v", err)
 	}
 
-	var jiraClient *jira.Client
-	{
-		var err error
-		jiraClient, err = jira.NewClient(
-			(&jira.BearerAuthTransport{Token: JIRA_TOKEN}).Client(),
-			query.JiraBaseURL,
-		)
-		if err != nil {
-			log.Fatalf("error building a Jira client: %v", err)
-		}
+	jiraClient, err := jiraclient.NewWithToken(query.JiraBaseURL, JIRA_TOKEN)
+	if err != nil {
+		log.Fatalf("error building a Jira client: %v", err)
 	}
 
 	var wg sync.WaitGroup

--- a/cmd/triage/main.go
+++ b/cmd/triage/main.go
@@ -10,6 +10,7 @@ import (
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/shiftstack/bugwatcher/cmd/triage/tasker"
+	"github.com/shiftstack/bugwatcher/pkg/jiraclient"
 	"github.com/shiftstack/bugwatcher/pkg/query"
 )
 
@@ -29,16 +30,9 @@ func main() {
 		log.Fatalf("error unmarshaling TEAM_MEMBERS_DICT: %v", err)
 	}
 
-	var jiraClient *jira.Client
-	{
-		var err error
-		jiraClient, err = jira.NewClient(
-			(&jira.BearerAuthTransport{Token: JIRA_TOKEN}).Client(),
-			query.JiraBaseURL,
-		)
-		if err != nil {
-			log.Fatalf("error building a Jira client: %v", err)
-		}
+	jiraClient, err := jiraclient.NewWithToken(query.JiraBaseURL, JIRA_TOKEN)
+	if err != nil {
+		log.Fatalf("error building a Jira client: %v", err)
 	}
 
 	var (

--- a/pkg/jiraclient/jiraclient.go
+++ b/pkg/jiraclient/jiraclient.go
@@ -1,0 +1,40 @@
+package jiraclient
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	jira "github.com/andygrunwald/go-jira"
+)
+
+type throttlingHttpClient struct {
+	*http.Client
+}
+
+func (c *throttlingHttpClient) Do(req *http.Request) (*http.Response, error) {
+	res, err := c.Client.Do(req)
+
+	if res.StatusCode == http.StatusTooManyRequests {
+		wait := time.Second * 1
+		if retryAfter := res.Header.Get("retry-after"); retryAfter != "" {
+			if n, err := strconv.Atoi(retryAfter); err != nil {
+				wait = time.Duration(n) * time.Second
+			}
+		}
+		log.Printf("Throttled by Jira: waiting %s", wait)
+		time.Sleep(wait)
+		return c.Do(req)
+	}
+
+	return res, err
+}
+
+// NewWithToken returns a Jira client that retries when hitting 429
+func NewWithToken(baseURL, jiraToken string) (jiraClient *jira.Client, err error) {
+	return jira.NewClient(
+		&throttlingHttpClient{(&jira.BearerAuthTransport{Token: jiraToken}).Client()},
+		baseURL,
+	)
+}


### PR DESCRIPTION
Our corporate Jira instance has implemented request throttling. This change introduces retries.