### PR TITLE
Ignore bugs labeled 'SecurityTracking'

### DIFF
--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -13,5 +13,7 @@ const ShiftStack = `project = "OpenShift Bugs"
 			"Test Framework / OpenStack",
 			"HyperShift / OpenStack"
 		)
-	) AND labels != "bugwatcher-ignore"
+	)
+	AND labels != "bugwatcher-ignore"
+	AND labels != "SecurityTracking"
 `


### PR DESCRIPTION
These are handled separately by the sustaining team. We don't need to triage them.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
